### PR TITLE
Update event image flow

### DIFF
--- a/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
@@ -27,8 +27,8 @@ struct CreateEventModel: Identifiable, Codable {
     var status: EventStatus
     var socialLinks: String
     var contactInfo: String
-    var imageURL: String
-    var hasGalleryImages: Bool
+    /// Ordered list of image URLs. Index 0 represents the cover image.
+    var imageUrls: [String]
     var createdAt: Date
     var updatedAt: Date
     var createdBy: String
@@ -51,8 +51,7 @@ struct CreateEventModel: Identifiable, Codable {
         status: EventStatus = .active,
         socialLinks: String = "",
         contactInfo: String = "",
-        imageURL: String = "",
-        hasGalleryImages: Bool = false,
+        imageUrls: [String] = [],
         createdBy: String = ""
     ) {
         self.title = title
@@ -72,8 +71,7 @@ struct CreateEventModel: Identifiable, Codable {
         self.status = status
         self.socialLinks = socialLinks
         self.contactInfo = contactInfo
-        self.imageURL = imageURL
-        self.hasGalleryImages = hasGalleryImages
+        self.imageUrls = imageUrls
         self.createdAt = Date()
         self.updatedAt = Date()
         self.createdBy = createdBy

--- a/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
@@ -41,8 +41,7 @@ class CreateEventViewModel: ObservableObject {
     @Published var status = "active"
     @Published var socialLinks = ""
     @Published var contactInfo = ""
-    @Published var imageURL = ""
-    @Published var hasGalleryImages = false
+    @Published var imageUrls: [String] = []
 
     @Published var isSaving = false
     @Published var errorMessage: String?
@@ -114,8 +113,7 @@ class CreateEventViewModel: ObservableObject {
             status: eventStatus,
             socialLinks: socialLinks,
             contactInfo: contactInfo,
-            imageURL: imageURL,
-            hasGalleryImages: hasGalleryImages,
+            imageUrls: imageUrls,
             createdBy: user.uid
         )
 

--- a/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
@@ -14,7 +14,7 @@ struct EventCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Event Banner Image
-            AsyncImage(url: URL(string: event.imageURL)) { image in
+            AsyncImage(url: URL(string: event.imageUrls.first ?? "")) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -142,7 +142,7 @@ struct EventCardView_Previews: PreviewProvider {
             location: EventLocation(name: "ITU Teknokent"),
             organizer: EventOrganizer(name: "İstanbul iOS Developers"),
             pricing: EventPricing(price: 0, currency: "TL"),
-            imageURL: "https://example.com/event-image.jpg",
+            imageUrls: ["https://example.com/event-image.jpg"],
             createdBy: "1"
         )
         


### PR DESCRIPTION
## Summary
- use single list of `imageUrls` in `CreateEventModel`
- support `imageUrls` when creating events
- show first image in `EventCardView`
- replace separate image sections with single `imagesSection` in `CreateEventView`
- allow selecting, reordering and choosing cover image
- fix compile issue by dropping `.editActions` and using edit mode

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_688c615a0478832096d3f7cbb83aa0b5