### PR TITLE
Refactor event image handling into unified upload

### DIFF
--- a/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
+++ b/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension UIImage {
+    func resized(toMax dimension: CGFloat) -> UIImage {
+        let maxSide = max(size.width, size.height)
+        guard maxSide > dimension else { return self }
+
+        let scale = dimension / maxSide
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}
+

--- a/Event Tracker/Event Tracker/Features/Events/Components/PhotoUploadView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Components/PhotoUploadView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoUploadView: View {
+    @Binding var images: [UIImage]
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var showingImagePicker = false
+    @State private var draggingImage: UIImage?
+
+    let thumbnailSize: CGFloat
+    let spacing: CGFloat
+    let maxPhotos: Int
+
+    init(images: Binding<[UIImage]>, thumbnailSize: CGFloat = 100, spacing: CGFloat = 12, maxPhotos: Int = 5) {
+        _images = images
+        self.thumbnailSize = thumbnailSize
+        self.spacing = spacing
+        self.maxPhotos = maxPhotos
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(images.indices, id: \.self) { index in
+                        PhotoThumbnail(image: images[index], size: thumbnailSize) {
+                            images.remove(at: index)
+                        }
+                        .onDrag {
+                            draggingImage = images[index]
+                            return NSItemProvider(object: "image_\(index)" as NSString)
+                        }
+                        .onDrop(of: [.text], delegate: ImageDropDelegate(image: images[index], images: $images, draggingImage: $draggingImage))
+                    }
+
+                    if images.count < maxPhotos {
+                        AddPhotoButton(size: thumbnailSize) {
+                            showingImagePicker = true
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .photosPicker(isPresented: $showingImagePicker,
+                      selection: $selectedItems,
+                      maxSelectionCount: maxPhotos - images.count,
+                      matching: .images)
+        .onChange(of: selectedItems) { items in
+            Task {
+                for item in items {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        images.append(image)
+                    }
+                }
+                selectedItems.removeAll()
+            }
+        }
+    }
+}
+
+private struct PhotoThumbnail: View {
+    let image: UIImage
+    let size: CGFloat
+    var onDelete: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size, height: size)
+                .clipped()
+                .cornerRadius(8)
+
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.white)
+                    .background(Circle().fill(Color.black.opacity(0.7)))
+            }
+            .padding(4)
+        }
+    }
+}
+
+private struct AddPhotoButton: View {
+    let size: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: size * 0.05) {
+                Image(systemName: "plus")
+                    .font(.system(size: size * 0.25, weight: .light))
+                    .foregroundColor(.gray)
+                Text("Fotoğraf\nEkle")
+                    .font(.system(size: size * 0.12))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.gray)
+            }
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+    }
+}
+
+private struct ImageDropDelegate: DropDelegate {
+    let image: UIImage
+    @Binding var images: [UIImage]
+    @Binding var draggingImage: UIImage?
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging = draggingImage,
+              dragging !== image,
+              let from = images.firstIndex(where: { $0 === dragging }),
+              let to = images.firstIndex(where: { $0 === image }) else { return }
+
+        withAnimation(.easeInOut) {
+            images.move(fromOffsets: IndexSet(integer: from), toOffset: to > from ? to + 1 : to)
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggingImage = nil
+        return true
+    }
+}
+

--- a/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
@@ -27,8 +27,8 @@ struct CreateEventModel: Identifiable, Codable {
     var status: EventStatus
     var socialLinks: String
     var contactInfo: String
-    var imageURL: String
-    var hasGalleryImages: Bool
+    var imageURLs: [String]
+    var thumbnailURLs: [String]
     var createdAt: Date
     var updatedAt: Date
     var createdBy: String
@@ -51,8 +51,8 @@ struct CreateEventModel: Identifiable, Codable {
         status: EventStatus = .active,
         socialLinks: String = "",
         contactInfo: String = "",
-        imageURL: String = "",
-        hasGalleryImages: Bool = false,
+        imageURLs: [String] = [],
+        thumbnailURLs: [String] = [],
         createdBy: String = ""
     ) {
         self.title = title
@@ -72,8 +72,8 @@ struct CreateEventModel: Identifiable, Codable {
         self.status = status
         self.socialLinks = socialLinks
         self.contactInfo = contactInfo
-        self.imageURL = imageURL
-        self.hasGalleryImages = hasGalleryImages
+        self.imageURLs = imageURLs
+        self.thumbnailURLs = thumbnailURLs
         self.createdAt = Date()
         self.updatedAt = Date()
         self.createdBy = createdBy

--- a/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
@@ -4,8 +4,6 @@ import Combine
 struct CreateEventView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = CreateEventViewModel()
-    @State private var showingImagePicker = false
-    @State private var showingGalleryPicker = false
     @State private var isLoading = false
     
     var body: some View {
@@ -21,8 +19,8 @@ struct CreateEventView: View {
                 
                 ScrollView {
                     LazyVStack(spacing: 32) {
-                        // MARK: - Event Image
-                        eventImageSection
+                        // MARK: - Event Photos
+                        photosSection
                         
                         // MARK: - Basic Info
                         basicInfoSection
@@ -47,9 +45,6 @@ struct CreateEventView: View {
                         
                         // MARK: - Additional Info
                         additionalInfoSection
-                        
-                        // MARK: - Gallery
-                        gallerySection
                         
                         Spacer(minLength: 20)
                     }
@@ -89,73 +84,14 @@ struct CreateEventView: View {
             }
         }
     }
-    
-    // MARK: - Event Image Section
-    private var eventImageSection: some View {
-        FormSectionCard(title: "Event Görseli", isRequired: true, icon: "photo") {
-            Button(action: {
-                showingImagePicker = true
-            }) {
-                if viewModel.imageURL.isEmpty {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(
-                            LinearGradient(
-                                colors: [Color.blue.opacity(0.1), Color.purple.opacity(0.1)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 12) {
-                                ZStack {
-                                    Circle()
-                                        .fill(Color.blue.opacity(0.1))
-                                        .frame(width: 60, height: 60)
-                                    
-                                    Image(systemName: "photo.badge.plus")
-                                        .font(.title2)
-                                        .foregroundColor(.blue)
-                                }
-                                
-                                VStack(spacing: 4) {
-                                    Text("Fotoğraf Seç")
-                                        .font(.headline)
-                                        .foregroundColor(.primary)
-                                    Text("Event'inizi en iyi şekilde temsil eden görseli seçin")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .multilineTextAlignment(.center)
-                                }
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.blue.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
-                        )
-                } else {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(Color.green.opacity(0.1))
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 8) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.largeTitle)
-                                    .foregroundColor(.green)
-                                Text("Görsel Seçildi")
-                                    .font(.headline)
-                                    .foregroundColor(.green)
-                            }
-                        )
-                }
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingImagePicker) {
-                Text("Image Picker - TODO")
-            }
+
+    // MARK: - Photos Section
+    private var photosSection: some View {
+        FormSectionCard(title: "Event Fotoğrafları", isRequired: true, icon: "photo.on.rectangle") {
+            PhotoUploadView(images: $viewModel.images)
         }
     }
-    
+
     // MARK: - Basic Info Section
     private var basicInfoSection: some View {
         FormSectionCard(title: "Temel Bilgiler", icon: "info.circle") {
@@ -290,51 +226,6 @@ struct CreateEventView: View {
                 
                 ModernTextField("Sosyal Medya Linkleri", text: $viewModel.socialLinks)
                 ModernTextField("İletişim Bilgileri", text: $viewModel.contactInfo)
-            }
-        }
-    }
-    
-    // MARK: - Gallery Section
-    private var gallerySection: some View {
-        FormSectionCard(title: "Galeri Görselleri", icon: "photo.stack") {
-            Button(action: {
-                showingGalleryPicker = true
-            }) {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05))
-                    .frame(height: 100)
-                    .overlay(
-                        VStack(spacing: 8) {
-                            Image(systemName: "photo.stack")
-                                .font(.title2)
-                                .foregroundColor(.blue)
-                            Text("Galeri Fotoğrafları Seç")
-                                .font(.subheadline)
-                                .foregroundColor(.blue)
-                            Text("Maksimum 5 fotoğraf")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.blue.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [3]))
-                    )
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingGalleryPicker) {
-                Text("Gallery Picker - TODO")
-            }
-            
-            if viewModel.hasGalleryImages {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Galeri fotoğrafları seçildi")
-                        .font(.caption)
-                        .foregroundColor(.green)
-                }
-                .padding(.top, 8)
             }
         }
     }

--- a/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
@@ -14,7 +14,7 @@ struct EventCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Event Banner Image
-            AsyncImage(url: URL(string: event.imageURL)) { image in
+            AsyncImage(url: URL(string: event.thumbnailURLs.first ?? event.imageURLs.first ?? "")) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -142,7 +142,8 @@ struct EventCardView_Previews: PreviewProvider {
             location: EventLocation(name: "ITU Teknokent"),
             organizer: EventOrganizer(name: "İstanbul iOS Developers"),
             pricing: EventPricing(price: 0, currency: "TL"),
-            imageURL: "https://example.com/event-image.jpg",
+            imageURLs: ["https://example.com/event-image.jpg"],
+            thumbnailURLs: [],
             createdBy: "1"
         )
         

--- a/Event Tracker/Event Tracker/Services/EventService.swift
+++ b/Event Tracker/Event Tracker/Services/EventService.swift
@@ -10,8 +10,16 @@ final class EventService {
         firestore.collection("events")
     }
 
-    func createEvent(_ event: CreateEventModel) async throws {
-        try eventsCollection.addDocument(from: event)
+    func generateEventID() -> String {
+        eventsCollection.document().documentID
+    }
+
+    func createEvent(_ event: CreateEventModel, id: String? = nil) async throws {
+        if let id = id {
+            try eventsCollection.document(id).setData(from: event)
+        } else {
+            try eventsCollection.addDocument(from: event)
+        }
     }
 
     func fetchEvents() async throws -> [CreateEventModel] {

--- a/Event Tracker/Event Tracker/Services/StorageService.swift
+++ b/Event Tracker/Event Tracker/Services/StorageService.swift
@@ -1,0 +1,37 @@
+import Foundation
+import FirebaseStorage
+import UIKit
+
+final class StorageService {
+    static let shared = StorageService()
+    private let storage = FirebaseManager.shared.storage
+    private init() {}
+
+    func uploadEventImages(_ images: [UIImage], eventId: String) async throws -> ([String], [String]) {
+        var imageURLs: [String] = []
+        var thumbnailURLs: [String] = []
+
+        for image in images {
+            let uuid = UUID().uuidString
+            let imageRef = storage.reference().child("events/\(eventId)/\(uuid).jpg")
+            let thumbRef = storage.reference().child("events/\(eventId)/\(uuid)_thumb.jpg")
+
+            let resized = image.resized(toMax: 1280)
+            if let data = resized.jpegData(compressionQuality: 0.8) {
+                _ = try await imageRef.putDataAsync(data, metadata: nil)
+                let url = try await imageRef.downloadURL()
+                imageURLs.append(url.absoluteString)
+            }
+
+            let thumbImage = image.resized(toMax: 300)
+            if let thumbData = thumbImage.jpegData(compressionQuality: 0.6) {
+                _ = try await thumbRef.putDataAsync(thumbData, metadata: nil)
+                let thumbURL = try await thumbRef.downloadURL()
+                thumbnailURLs.append(thumbURL.absoluteString)
+            }
+        }
+
+        return (imageURLs, thumbnailURLs)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Replace separate cover and gallery images with a single photo upload workflow
- Store event images and thumbnails in Firebase Storage with JPEG compression
- Update models, services, and views to handle multiple images

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68906e5c89f08320b41adc2507b223e5