### PR TITLE
Unify event image handling and add Firebase Storage uploads

### DIFF
--- a/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
+++ b/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+extension UIImage {
+    func resized(toMaxDimension maxDimension: CGFloat) -> UIImage {
+        let aspectRatio = size.width / size.height
+        let newSize: CGSize
+        if aspectRatio > 1 {
+            newSize = CGSize(width: maxDimension, height: maxDimension / aspectRatio)
+        } else {
+            newSize = CGSize(width: maxDimension * aspectRatio, height: maxDimension)
+        }
+
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}
+

--- a/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
@@ -27,8 +27,7 @@ struct CreateEventModel: Identifiable, Codable {
     var status: EventStatus
     var socialLinks: String
     var contactInfo: String
-    var imageURL: String
-    var hasGalleryImages: Bool
+    var images: [EventImage]
     var createdAt: Date
     var updatedAt: Date
     var createdBy: String
@@ -51,8 +50,7 @@ struct CreateEventModel: Identifiable, Codable {
         status: EventStatus = .active,
         socialLinks: String = "",
         contactInfo: String = "",
-        imageURL: String = "",
-        hasGalleryImages: Bool = false,
+        images: [EventImage] = [],
         createdBy: String = ""
     ) {
         self.title = title
@@ -72,11 +70,20 @@ struct CreateEventModel: Identifiable, Codable {
         self.status = status
         self.socialLinks = socialLinks
         self.contactInfo = contactInfo
-        self.imageURL = imageURL
-        self.hasGalleryImages = hasGalleryImages
+        self.images = images
         self.createdAt = Date()
         self.updatedAt = Date()
         self.createdBy = createdBy
+    }
+}
+
+struct EventImage: Codable {
+    var url: String
+    var thumbnailURL: String
+
+    init(url: String = "", thumbnailURL: String = "") {
+        self.url = url
+        self.thumbnailURL = thumbnailURL
     }
 }
 

--- a/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import FirebaseAuth
 import Combine
+import UIKit
 
 @MainActor
 class CreateEventViewModel: ObservableObject {
@@ -41,8 +42,7 @@ class CreateEventViewModel: ObservableObject {
     @Published var status = "active"
     @Published var socialLinks = ""
     @Published var contactInfo = ""
-    @Published var imageURL = ""
-    @Published var hasGalleryImages = false
+    @Published var images: [UIImage] = []
 
     @Published var isSaving = false
     @Published var errorMessage: String?
@@ -96,6 +96,16 @@ class CreateEventViewModel: ObservableObject {
             return
         }
 
+        var uploadedImages: [EventImage] = []
+        if !images.isEmpty {
+            do {
+                uploadedImages = try await ImageStorageService.shared.uploadImages(images)
+                images.removeAll()
+            } catch {
+                errorMessage = "Görseller yüklenemedi: \(error.localizedDescription)"
+            }
+        }
+
         let event = CreateEventModel(
             title: title,
             description: description,
@@ -114,8 +124,7 @@ class CreateEventViewModel: ObservableObject {
             status: eventStatus,
             socialLinks: socialLinks,
             contactInfo: contactInfo,
-            imageURL: imageURL,
-            hasGalleryImages: hasGalleryImages,
+            images: uploadedImages,
             createdBy: user.uid
         )
 

--- a/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
@@ -4,8 +4,6 @@ import Combine
 struct CreateEventView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = CreateEventViewModel()
-    @State private var showingImagePicker = false
-    @State private var showingGalleryPicker = false
     @State private var isLoading = false
     
     var body: some View {
@@ -21,9 +19,9 @@ struct CreateEventView: View {
                 
                 ScrollView {
                     LazyVStack(spacing: 32) {
-                        // MARK: - Event Image
-                        eventImageSection
-                        
+                        // MARK: - Photos
+                        photoSection
+
                         // MARK: - Basic Info
                         basicInfoSection
                         
@@ -47,9 +45,6 @@ struct CreateEventView: View {
                         
                         // MARK: - Additional Info
                         additionalInfoSection
-                        
-                        // MARK: - Gallery
-                        gallerySection
                         
                         Spacer(minLength: 20)
                     }
@@ -90,72 +85,13 @@ struct CreateEventView: View {
         }
     }
     
-    // MARK: - Event Image Section
-    private var eventImageSection: some View {
-        FormSectionCard(title: "Event Görseli", isRequired: true, icon: "photo") {
-            Button(action: {
-                showingImagePicker = true
-            }) {
-                if viewModel.imageURL.isEmpty {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(
-                            LinearGradient(
-                                colors: [Color.blue.opacity(0.1), Color.purple.opacity(0.1)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 12) {
-                                ZStack {
-                                    Circle()
-                                        .fill(Color.blue.opacity(0.1))
-                                        .frame(width: 60, height: 60)
-                                    
-                                    Image(systemName: "photo.badge.plus")
-                                        .font(.title2)
-                                        .foregroundColor(.blue)
-                                }
-                                
-                                VStack(spacing: 4) {
-                                    Text("Fotoğraf Seç")
-                                        .font(.headline)
-                                        .foregroundColor(.primary)
-                                    Text("Event'inizi en iyi şekilde temsil eden görseli seçin")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .multilineTextAlignment(.center)
-                                }
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.blue.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
-                        )
-                } else {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(Color.green.opacity(0.1))
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 8) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.largeTitle)
-                                    .foregroundColor(.green)
-                                Text("Görsel Seçildi")
-                                    .font(.headline)
-                                    .foregroundColor(.green)
-                            }
-                        )
-                }
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingImagePicker) {
-                Text("Image Picker - TODO")
-            }
+    // MARK: - Photo Upload Section
+    private var photoSection: some View {
+        FormSectionCard(title: "Fotoğraflar", isRequired: true, icon: "photo.on.rectangle") {
+            PhotoUploadView(selectedImages: $viewModel.images)
         }
     }
-    
+
     // MARK: - Basic Info Section
     private var basicInfoSection: some View {
         FormSectionCard(title: "Temel Bilgiler", icon: "info.circle") {
@@ -295,49 +231,6 @@ struct CreateEventView: View {
     }
     
     // MARK: - Gallery Section
-    private var gallerySection: some View {
-        FormSectionCard(title: "Galeri Görselleri", icon: "photo.stack") {
-            Button(action: {
-                showingGalleryPicker = true
-            }) {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05))
-                    .frame(height: 100)
-                    .overlay(
-                        VStack(spacing: 8) {
-                            Image(systemName: "photo.stack")
-                                .font(.title2)
-                                .foregroundColor(.blue)
-                            Text("Galeri Fotoğrafları Seç")
-                                .font(.subheadline)
-                                .foregroundColor(.blue)
-                            Text("Maksimum 5 fotoğraf")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.blue.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [3]))
-                    )
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingGalleryPicker) {
-                Text("Gallery Picker - TODO")
-            }
-            
-            if viewModel.hasGalleryImages {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Galeri fotoğrafları seçildi")
-                        .font(.caption)
-                        .foregroundColor(.green)
-                }
-                .padding(.top, 8)
-            }
-        }
-    }
     
     // MARK: - Helper Functions
     private func saveEvent() {

--- a/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
@@ -14,7 +14,7 @@ struct EventCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Event Banner Image
-            AsyncImage(url: URL(string: event.imageURL)) { image in
+            AsyncImage(url: URL(string: event.images.first?.thumbnailURL ?? "")) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -142,7 +142,7 @@ struct EventCardView_Previews: PreviewProvider {
             location: EventLocation(name: "ITU Teknokent"),
             organizer: EventOrganizer(name: "İstanbul iOS Developers"),
             pricing: EventPricing(price: 0, currency: "TL"),
-            imageURL: "https://example.com/event-image.jpg",
+            images: [EventImage(url: "https://example.com/event-image.jpg", thumbnailURL: "https://example.com/event-image-thumb.jpg")],
             createdBy: "1"
         )
         

--- a/Event Tracker/Event Tracker/Features/Events/Views/PhotoUploadView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/PhotoUploadView.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoUploadView: View {
+    @Binding var selectedImages: [UIImage]
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var draggingImage: UIImage?
+    @State private var showingViewer = false
+    @State private var viewerIndex = 0
+
+    let thumbnailSize: CGFloat
+    let spacing: CGFloat
+    let maxPhotos: Int
+
+    init(selectedImages: Binding<[UIImage]>, thumbnailSize: CGFloat = 100, spacing: CGFloat = 12, maxPhotos: Int = 5) {
+        self._selectedImages = selectedImages
+        self.thumbnailSize = thumbnailSize
+        self.spacing = spacing
+        self.maxPhotos = maxPhotos
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            Text("Fotoğraflar (\(selectedImages.count)/\(maxPhotos))")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.primary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(selectedImages.indices, id: \.self) { index in
+                        PhotoThumbnail(
+                            image: selectedImages[index],
+                            size: thumbnailSize,
+                            onDelete: {
+                                selectedImages.remove(at: index)
+                            }
+                        )
+                        .onTapGesture {
+                            viewerIndex = index
+                            showingViewer = true
+                        }
+                        .onDrag {
+                            draggingImage = selectedImages[index]
+                            return NSItemProvider(object: "image_\(index)" as NSString)
+                        }
+                        .onDrop(
+                            of: [.text],
+                            delegate: ImageDropDelegate(
+                                image: selectedImages[index],
+                                images: $selectedImages,
+                                draggingImage: $draggingImage
+                            )
+                        )
+                    }
+
+                    if selectedImages.count < maxPhotos {
+                        PhotosPicker(
+                            selection: $selectedItems,
+                            maxSelectionCount: maxPhotos - selectedImages.count,
+                            matching: .images
+                        ) {
+                            AddPhotoButton(size: thumbnailSize) {}
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .onChange(of: selectedItems) { items in
+            Task {
+                for item in items {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        selectedImages.append(image)
+                    }
+                }
+                selectedItems.removeAll()
+            }
+        }
+        .fullScreenCover(isPresented: $showingViewer) {
+            ImageViewer(images: selectedImages, index: $viewerIndex)
+        }
+    }
+}
+
+struct PhotoThumbnail: View {
+    let image: UIImage
+    let size: CGFloat
+    let onDelete: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size, height: size)
+                .clipped()
+                .cornerRadius(8)
+
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.white)
+                    .background(Circle().fill(Color.black.opacity(0.7)))
+                    .font(.system(size: max(12, size * 0.15)))
+            }
+            .padding(4)
+        }
+    }
+}
+
+struct AddPhotoButton: View {
+    let size: CGFloat
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: size * 0.05) {
+                Image(systemName: "plus")
+                    .font(.system(size: size * 0.25, weight: .light))
+                    .foregroundColor(.gray)
+
+                Text("Fotoğraf\nEkle")
+                    .font(.system(size: size * 0.12))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.gray)
+            }
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+    }
+}
+
+private struct ImageDropDelegate: DropDelegate {
+    let image: UIImage
+    @Binding var images: [UIImage]
+    @Binding var draggingImage: UIImage?
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard
+            let dragging = draggingImage,
+            dragging !== image,
+            let from = images.firstIndex(where: { $0 === dragging }),
+            let to = images.firstIndex(where: { $0 === image })
+        else { return }
+
+        withAnimation(.easeInOut) {
+            images.move(
+                fromOffsets: IndexSet(integer: from),
+                toOffset: to > from ? to + 1 : to
+            )
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggingImage = nil
+        return true
+    }
+}
+
+// MARK: - Full Screen Viewer
+
+struct ImageViewer: View {
+    let images: [UIImage]
+    @Binding var index: Int
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            TabView(selection: $index) {
+                ForEach(images.indices, id: \.self) { i in
+                    ZoomableScrollView(image: images[i])
+                        .tag(i)
+                        .background(Color.black)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .automatic))
+            .background(Color.black)
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.largeTitle)
+                    .foregroundColor(.white)
+                    .padding()
+            }
+        }
+        .background(Color.black.ignoresSafeArea())
+        .gesture(
+            DragGesture().onEnded { value in
+                if value.translation.height > 200 {
+                    dismiss()
+                }
+            }
+        )
+    }
+}
+
+struct ZoomableScrollView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 4.0
+        scrollView.delegate = context.coordinator
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.frame = scrollView.bounds
+        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        scrollView.addSubview(imageView)
+        context.coordinator.imageView = imageView
+        return scrollView
+    }
+
+    func updateUIView(_ uiView: UIScrollView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator: NSObject, UIScrollViewDelegate {
+        var imageView: UIImageView?
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            return imageView
+        }
+    }
+}
+

--- a/Event Tracker/Event Tracker/Services/ImageStorageService.swift
+++ b/Event Tracker/Event Tracker/Services/ImageStorageService.swift
@@ -1,0 +1,58 @@
+import UIKit
+import FirebaseStorage
+
+final class ImageStorageService {
+    static let shared = ImageStorageService()
+    private let storage = FirebaseManager.shared.storage
+
+    private init() {}
+
+    func uploadImages(_ images: [UIImage]) async throws -> [EventImage] {
+        var uploaded: [EventImage] = []
+        for image in images {
+            let id = UUID().uuidString
+            let full = image.resized(toMaxDimension: 1024)
+            let thumb = image.resized(toMaxDimension: 300)
+
+            guard let fullData = full.jpegData(compressionQuality: 0.8),
+                  let thumbData = thumb.jpegData(compressionQuality: 0.6) else { continue }
+
+            let fullRef = storage.reference().child("events/\(id).jpg")
+            let thumbRef = storage.reference().child("events/\(id)_thumb.jpg")
+
+            try await putData(fullRef, data: fullData)
+            try await putData(thumbRef, data: thumbData)
+
+            let fullURL = try await downloadURL(fullRef)
+            let thumbURL = try await downloadURL(thumbRef)
+
+            uploaded.append(EventImage(url: fullURL.absoluteString, thumbnailURL: thumbURL.absoluteString))
+        }
+        return uploaded
+    }
+
+    private func putData(_ ref: StorageReference, data: Data) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            ref.putData(data, metadata: nil) { _, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    private func downloadURL(_ ref: StorageReference) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            ref.downloadURL { url, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let url = url {
+                    continuation.resume(returning: url)
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace separate cover and gallery pickers with a single photo uploader
- upload images and thumbnails to Firebase Storage and store URLs on the event model
- add full screen image viewer with zoom and swipe-to-dismiss

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68908b29a3a08320afd12e98214beb6c