### PR TITLE
Unify event photo uploads with Firebase storage integration

### DIFF
--- a/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
+++ b/Event Tracker/Event Tracker/Core/Extensions/UIImage+Resize.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+extension UIImage {
+    func resized(to maxDimension: CGFloat) -> UIImage {
+        let aspectRatio = size.width / size.height
+        var newSize: CGSize
+        if aspectRatio > 1 {
+            newSize = CGSize(width: maxDimension, height: maxDimension / aspectRatio)
+        } else {
+            newSize = CGSize(width: maxDimension * aspectRatio, height: maxDimension)
+        }
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}

--- a/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Models/CreateEventModel.swift
@@ -27,8 +27,7 @@ struct CreateEventModel: Identifiable, Codable {
     var status: EventStatus
     var socialLinks: String
     var contactInfo: String
-    var imageURL: String
-    var hasGalleryImages: Bool
+    var images: [EventImage]
     var createdAt: Date
     var updatedAt: Date
     var createdBy: String
@@ -51,8 +50,7 @@ struct CreateEventModel: Identifiable, Codable {
         status: EventStatus = .active,
         socialLinks: String = "",
         contactInfo: String = "",
-        imageURL: String = "",
-        hasGalleryImages: Bool = false,
+        images: [EventImage] = [],
         createdBy: String = ""
     ) {
         self.title = title
@@ -72,8 +70,7 @@ struct CreateEventModel: Identifiable, Codable {
         self.status = status
         self.socialLinks = socialLinks
         self.contactInfo = contactInfo
-        self.imageURL = imageURL
-        self.hasGalleryImages = hasGalleryImages
+        self.images = images
         self.createdAt = Date()
         self.updatedAt = Date()
         self.createdBy = createdBy

--- a/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
+++ b/Event Tracker/Event Tracker/Features/Events/ViewModels/CreateEventViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 import FirebaseAuth
 import Combine
 
@@ -41,8 +42,7 @@ class CreateEventViewModel: ObservableObject {
     @Published var status = "active"
     @Published var socialLinks = ""
     @Published var contactInfo = ""
-    @Published var imageURL = ""
-    @Published var hasGalleryImages = false
+    @Published var selectedImages: [UIImage] = []
 
     @Published var isSaving = false
     @Published var errorMessage: String?
@@ -96,6 +96,9 @@ class CreateEventViewModel: ObservableObject {
             return
         }
 
+        let uploadedImages = try? await ImageUploader.upload(images: selectedImages)
+        selectedImages.removeAll()
+
         let event = CreateEventModel(
             title: title,
             description: description,
@@ -114,8 +117,7 @@ class CreateEventViewModel: ObservableObject {
             status: eventStatus,
             socialLinks: socialLinks,
             contactInfo: contactInfo,
-            imageURL: imageURL,
-            hasGalleryImages: hasGalleryImages,
+            images: uploadedImages ?? [],
             createdBy: user.uid
         )
 

--- a/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/CreateEventView.swift
@@ -4,8 +4,6 @@ import Combine
 struct CreateEventView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = CreateEventViewModel()
-    @State private var showingImagePicker = false
-    @State private var showingGalleryPicker = false
     @State private var isLoading = false
     
     var body: some View {
@@ -21,8 +19,8 @@ struct CreateEventView: View {
                 
                 ScrollView {
                     LazyVStack(spacing: 32) {
-                        // MARK: - Event Image
-                        eventImageSection
+                        // MARK: - Photos
+                        photoSection
                         
                         // MARK: - Basic Info
                         basicInfoSection
@@ -48,8 +46,6 @@ struct CreateEventView: View {
                         // MARK: - Additional Info
                         additionalInfoSection
                         
-                        // MARK: - Gallery
-                        gallerySection
                         
                         Spacer(minLength: 20)
                     }
@@ -90,69 +86,10 @@ struct CreateEventView: View {
         }
     }
     
-    // MARK: - Event Image Section
-    private var eventImageSection: some View {
-        FormSectionCard(title: "Event Görseli", isRequired: true, icon: "photo") {
-            Button(action: {
-                showingImagePicker = true
-            }) {
-                if viewModel.imageURL.isEmpty {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(
-                            LinearGradient(
-                                colors: [Color.blue.opacity(0.1), Color.purple.opacity(0.1)],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 12) {
-                                ZStack {
-                                    Circle()
-                                        .fill(Color.blue.opacity(0.1))
-                                        .frame(width: 60, height: 60)
-                                    
-                                    Image(systemName: "photo.badge.plus")
-                                        .font(.title2)
-                                        .foregroundColor(.blue)
-                                }
-                                
-                                VStack(spacing: 4) {
-                                    Text("Fotoğraf Seç")
-                                        .font(.headline)
-                                        .foregroundColor(.primary)
-                                    Text("Event'inizi en iyi şekilde temsil eden görseli seçin")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .multilineTextAlignment(.center)
-                                }
-                            }
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.blue.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
-                        )
-                } else {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(Color.green.opacity(0.1))
-                        .frame(height: 200)
-                        .overlay(
-                            VStack(spacing: 8) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.largeTitle)
-                                    .foregroundColor(.green)
-                                Text("Görsel Seçildi")
-                                    .font(.headline)
-                                    .foregroundColor(.green)
-                            }
-                        )
-                }
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingImagePicker) {
-                Text("Image Picker - TODO")
-            }
+    // MARK: - Photo Section
+    private var photoSection: some View {
+        FormSectionCard(title: "Event Fotoğrafları", isRequired: true, icon: "photo.on.rectangle") {
+            PhotoUploadView(images: $viewModel.selectedImages)
         }
     }
     
@@ -294,50 +231,6 @@ struct CreateEventView: View {
         }
     }
     
-    // MARK: - Gallery Section
-    private var gallerySection: some View {
-        FormSectionCard(title: "Galeri Görselleri", icon: "photo.stack") {
-            Button(action: {
-                showingGalleryPicker = true
-            }) {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05))
-                    .frame(height: 100)
-                    .overlay(
-                        VStack(spacing: 8) {
-                            Image(systemName: "photo.stack")
-                                .font(.title2)
-                                .foregroundColor(.blue)
-                            Text("Galeri Fotoğrafları Seç")
-                                .font(.subheadline)
-                                .foregroundColor(.blue)
-                            Text("Maksimum 5 fotoğraf")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.blue.opacity(0.2), style: StrokeStyle(lineWidth: 1, dash: [3]))
-                    )
-            }
-            .buttonStyle(ScaleButtonStyle())
-            .sheet(isPresented: $showingGalleryPicker) {
-                Text("Gallery Picker - TODO")
-            }
-            
-            if viewModel.hasGalleryImages {
-                HStack {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                    Text("Galeri fotoğrafları seçildi")
-                        .font(.caption)
-                        .foregroundColor(.green)
-                }
-                .padding(.top, 8)
-            }
-        }
-    }
     
     // MARK: - Helper Functions
     private func saveEvent() {
@@ -356,6 +249,7 @@ struct CreateEventView: View {
         !viewModel.locationName.isEmpty &&
         !viewModel.organizerName.isEmpty &&
         !viewModel.selectedCategories.isEmpty &&
+        !viewModel.selectedImages.isEmpty &&
         !viewModel.price.isEmpty
     }
 }

--- a/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/EventCardView.swift
@@ -14,7 +14,7 @@ struct EventCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Event Banner Image
-            AsyncImage(url: URL(string: event.imageURL)) { image in
+            AsyncImage(url: URL(string: event.images.first?.url ?? "")) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -142,7 +142,7 @@ struct EventCardView_Previews: PreviewProvider {
             location: EventLocation(name: "ITU Teknokent"),
             organizer: EventOrganizer(name: "İstanbul iOS Developers"),
             pricing: EventPricing(price: 0, currency: "TL"),
-            imageURL: "https://example.com/event-image.jpg",
+            images: [EventImage(url: "https://example.com/event-image.jpg", thumbnailUrl: "https://example.com/event-image-thumb.jpg")],
             createdBy: "1"
         )
         

--- a/Event Tracker/Event Tracker/Features/Events/Views/PhotoUploadView.swift
+++ b/Event Tracker/Event Tracker/Features/Events/Views/PhotoUploadView.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import PhotosUI
+
+struct PhotoUploadView: View {
+    @Binding var images: [UIImage]
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var draggingImage: UIImage?
+    @State private var previewIndex: Int?
+    @State private var showingImagePicker = false
+    
+    let thumbnailSize: CGFloat
+    let spacing: CGFloat
+    let showTitle: Bool
+    let maxPhotos: Int
+    
+    init(images: Binding<[UIImage]>, thumbnailSize: CGFloat = 100, spacing: CGFloat = 12, showTitle: Bool = true, maxPhotos: Int = 5) {
+        self._images = images
+        self.thumbnailSize = thumbnailSize
+        self.spacing = spacing
+        self.showTitle = showTitle
+        self.maxPhotos = maxPhotos
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            if showTitle {
+                Text("Fotoğraflar (\(images.count)/\(maxPhotos))")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(.primary)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(images.indices, id: \.self) { index in
+                        PhotoThumbnail(image: images[index], size: thumbnailSize) {
+                            images.remove(at: index)
+                        }
+                        .onTapGesture { previewIndex = index }
+                        .onDrag {
+                            draggingImage = images[index]
+                            return NSItemProvider(object: "image_\(index)" as NSString)
+                        }
+                        .onDrop(of: [.text], delegate: ImageDropDelegate(image: images[index], images: $images, draggingImage: $draggingImage))
+                    }
+                    if images.count < maxPhotos {
+                        AddPhotoButton(size: thumbnailSize) {
+                            showingImagePicker = true
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .photosPicker(isPresented: $showingImagePicker, selection: $selectedItems, maxSelectionCount: maxPhotos - images.count, matching: .images)
+        .onChange(of: selectedItems) { items in
+            Task {
+                for item in items {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        images.append(image)
+                    }
+                }
+                selectedItems.removeAll()
+            }
+        }
+        .fullScreenCover(isPresented: Binding(get: { previewIndex != nil }, set: { if !$0 { previewIndex = nil } })) {
+            if let index = previewIndex {
+                FullScreenImageView(image: images[index])
+            }
+        }
+    }
+}
+
+struct PhotoThumbnail: View {
+    let image: UIImage
+    let size: CGFloat
+    let onDelete: () -> Void
+    
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size, height: size)
+                .clipped()
+                .cornerRadius(8)
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.white)
+                    .background(Circle().fill(Color.black.opacity(0.7)))
+                    .font(.system(size: max(12, size * 0.15)))
+            }
+            .padding(4)
+        }
+    }
+}
+
+struct AddPhotoButton: View {
+    let size: CGFloat
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: size * 0.05) {
+                Image(systemName: "plus")
+                    .font(.system(size: size * 0.25, weight: .light))
+                    .foregroundColor(.gray)
+                Text("Fotoğraf\nEkle")
+                    .font(.system(size: size * 0.12))
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.gray)
+            }
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+    }
+}
+
+private struct ImageDropDelegate: DropDelegate {
+    let image: UIImage
+    @Binding var images: [UIImage]
+    @Binding var draggingImage: UIImage?
+    
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+    
+    func dropEntered(info: DropInfo) {
+        guard let dragging = draggingImage,
+              dragging !== image,
+              let from = images.firstIndex(where: { $0 === dragging }),
+              let to = images.firstIndex(where: { $0 === image }) else { return }
+        withAnimation(.easeInOut) {
+            images.move(fromOffsets: IndexSet(integer: from), toOffset: to > from ? to + 1 : to)
+        }
+    }
+    
+    func performDrop(info: DropInfo) -> Bool {
+        draggingImage = nil
+        return true
+    }
+}
+
+struct FullScreenImageView: View {
+    let image: UIImage
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        ZoomableScrollView(image: image)
+            .ignoresSafeArea()
+            .background(Color.black)
+            .overlay(alignment: .topTrailing) {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title)
+                        .foregroundColor(.white)
+                        .padding()
+                }
+            }
+            .gesture(DragGesture().onEnded { value in
+                if value.translation.height > 100 { dismiss() }
+            })
+    }
+}
+
+struct ZoomableScrollView: UIViewRepresentable {
+    let image: UIImage
+    
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 4
+        scrollView.delegate = context.coordinator
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.frame = UIScreen.main.bounds
+        scrollView.addSubview(imageView)
+        context.coordinator.imageView = imageView
+        return scrollView
+    }
+    
+    func updateUIView(_ uiView: UIScrollView, context: Context) {
+        // no-op
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    
+    class Coordinator: NSObject, UIScrollViewDelegate {
+        var imageView: UIImageView?
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+    }
+}

--- a/Event Tracker/Event Tracker/Models/EventImage.swift
+++ b/Event Tracker/Event Tracker/Models/EventImage.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct EventImage: Identifiable, Codable {
+    var id: String = UUID().uuidString
+    let url: String
+    let thumbnailUrl: String
+}

--- a/Event Tracker/Event Tracker/Services/ImageUploader.swift
+++ b/Event Tracker/Event Tracker/Services/ImageUploader.swift
@@ -1,0 +1,26 @@
+import UIKit
+import FirebaseStorage
+
+final class ImageUploader {
+    private static let storage = FirebaseManager.shared.storage
+    
+    static func upload(images: [UIImage]) async throws -> [EventImage] {
+        var uploaded: [EventImage] = []
+        let storageRef = storage.reference().child("events")
+        for image in images {
+            let id = UUID().uuidString
+            let mainRef = storageRef.child("images/\(id).jpg")
+            let thumbRef = storageRef.child("thumbnails/\(id).jpg")
+            let mainData = image.resized(to: 1280).jpegData(compressionQuality: 0.7)
+            let thumbData = image.resized(to: 300).jpegData(compressionQuality: 0.3)
+            if let mainData, let thumbData {
+                _ = try await mainRef.putDataAsync(mainData)
+                _ = try await thumbRef.putDataAsync(thumbData)
+                let mainURL = try await mainRef.downloadURL()
+                let thumbURL = try await thumbRef.downloadURL()
+                uploaded.append(EventImage(url: mainURL.absoluteString, thumbnailUrl: thumbURL.absoluteString))
+            }
+        }
+        return uploaded
+    }
+}


### PR DESCRIPTION
## Summary
- replace separate cover/gallery sections with a single `PhotoUploadView` allowing multiple images, drag-and-drop reordering and full-screen zoomable previews
- upload selected images to Firebase Storage with JPEG compression and thumbnails via new `ImageUploader`
- store image URLs in `CreateEventModel` and display first image in event cards

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68908b29a3a08320afd12e98214beb6c